### PR TITLE
Fix typo in Upstart script

### DIFF
--- a/templates/uwsgi_upstart.conf.erb
+++ b/templates/uwsgi_upstart.conf.erb
@@ -13,7 +13,7 @@ pre-start script
     uwsgilog="<%= @log_file %>"
     uwsgipid="<%= @pidfile %>"
     uwsgisocket="<%= @socket %>"
-    uwsgilogddir="${uwsgilogd%/*}"
+    uwsgilogdir="${uwsgilog%/*}"
     uwsgipiddir="${uwsgipid%/*}"
     uwsgisocketdir="${uwsgisocket%/*}"
     mkdir -p "$uwsgipiddir"


### PR DESCRIPTION
uWSGI could not start with upstart because of a typo. This fixes it.
