### PR TITLE
Support repeated application options by passing an array of values

### DIFF
--- a/templates/uwsgi_app.ini.erb
+++ b/templates/uwsgi_app.ini.erb
@@ -9,9 +9,17 @@ gid = <%= @gid %>
 <%
 if @application_options
   @application_options.sort.each do |key, value|
+    if value.is_a? Array
+      value.each do |v|
+-%>
+<%= key %> = <%= v%>
+<%
+      end
+    else
 -%>
 <%= key %> = <%= value%>
 <%
+    end
   end
 end
 


### PR DESCRIPTION
The motivating example was:

  $application_options => {
    py-autoreload => 1,
    touch-reload => [
      'file1',
      'file2',
      'file3',
    ],
  }

Signed-off-by: Ray Lehtiniemi rayl@mail.com
