### PR TITLE
Fix checks for created directories

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -222,28 +222,34 @@ class uwsgi (
         creates => $log_directory,
         command => "mkdir -p ${log_directory}",
         path    => $::path
-    } -> file { $log_directory: }
+    } -> file { $log_directory:
+        ensure => 'directory'
+    }
 
     exec { $pid_directory:
         creates => $pid_directory,
         command => "mkdir -p ${pid_directory}",
         path    => $::path
-    } -> file { $pid_directory: }
+    } -> file { $pid_directory:
+        ensure => 'directory'
+    }
 
     if $socket_directory != $pid_directory {
       exec { $socket_directory:
           creates => $socket_directory,
           command => "mkdir -p ${socket_directory}",
           path    => $::path
-      } -> file { $socket_directory: }
+      } -> file { $socket_directory:
+          ensure => 'directory'
+      }
     }
 
-    file { $app_directory:
-        ensure  => 'directory',
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0644',
-        require => Package[$package_name]
+    exec { $app_directory:
+        creates => $app_directory,
+        command => "mkdir -p ${app_directory}",
+        path    => $::path
+    } -> file { $app_directory:
+        ensure => 'directory'
     }
 
     service { $service_name:

--- a/templates/uwsgi_systemd.service.erb
+++ b/templates/uwsgi_systemd.service.erb
@@ -8,7 +8,7 @@ Description=uWSGI Emperor
 After=syslog.target
 
 [Service]
-ExecStart=<%= @binary_directory %>/uwsgi --die-on-term --ini <%= @config_file %>
+ExecStart=<%= @binary_directory %>/uwsgi --ini <%= @config_file %>
 # Requires systemd version 211 or newer
 RuntimeDirectory=uwsgi
 Restart=always


### PR DESCRIPTION
The current checks for the created directories does not specify the
`ensure` parameter which defaults to `file` and thus will fail.

Also fixes rvdh/puppet-uwsgi#9