### PR TITLE
Declare directories instead of using `exec`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -218,24 +218,18 @@ class uwsgi (
     $pid_directory = dirname($pidfile)
     $socket_directory = dirname($socket)
 
-    exec { $log_directory:
-        creates => $log_directory,
-        command => "mkdir -p ${log_directory}",
-        path    => $::path
-    } -> file { $log_directory: }
+    file { $log_directory:
+      ensure => 'directory',
+    }
 
-    exec { $pid_directory:
-        creates => $pid_directory,
-        command => "mkdir -p ${pid_directory}",
-        path    => $::path
-    } -> file { $pid_directory: }
+    file { $pid_directory:
+      ensure => 'directory',
+    }
 
     if $socket_directory != $pid_directory {
-      exec { $socket_directory:
-          creates => $socket_directory,
-          command => "mkdir -p ${socket_directory}",
-          path    => $::path
-      } -> file { $socket_directory: }
+      file { $socket_directory:
+        ensure => 'directory',
+      }
     }
 
     file { $app_directory:


### PR DESCRIPTION
We are encountering errors when using this module:

```
(/Stage[main]/<redacted>::Config/Ini_setting[/path/to/file [config] value]/ensure) change from absent to present failed: Could not set 'present' on ensure: No such file or directory @ rb_sysopen - /path/to/file
```

Instead of using `exec`, we declare that the directory exists.